### PR TITLE
Improved Zoom feature; Small fixes

### DIFF
--- a/PixelMatcher/Helpers/ImageHelper.cs
+++ b/PixelMatcher/Helpers/ImageHelper.cs
@@ -29,6 +29,7 @@ namespace PixelMatcher.Helpers
 
         public static BitmapImage Convert(Image src)
         {
+            if (src == null) return null;
             using (MemoryStream ms = new MemoryStream())
             {
                 src.Save(ms, ImageFormat.Bmp);

--- a/PixelMatcher/Helpers/ScreenHelper.cs
+++ b/PixelMatcher/Helpers/ScreenHelper.cs
@@ -1,0 +1,26 @@
+﻿using System.Drawing;
+using System.Windows.Forms;
+using System.Windows.Media.Imaging;
+
+namespace PixelMatcher.Helpers
+{
+    internal static class ScreenHelper
+    {
+        public static BitmapImage GetScreenshot()
+        {
+            int screenLeft = SystemInformation.VirtualScreen.Left;
+            int screenTop = SystemInformation.VirtualScreen.Top;
+            int screenWidth = SystemInformation.VirtualScreen.Width;
+            int screenHeight = SystemInformation.VirtualScreen.Height;
+
+            using (var bitmap = new Bitmap(screenWidth, screenHeight))
+            {
+                using (var g = Graphics.FromImage(bitmap))
+                {
+                    g.CopyFromScreen(screenLeft, screenTop, 0, 0, bitmap.Size);
+                }
+                return ImageHelper.Convert(bitmap);
+            }
+        }
+    }
+}

--- a/PixelMatcher/PixelMatcher.csproj
+++ b/PixelMatcher/PixelMatcher.csproj
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Update="Resources\WindowResources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/PixelMatcher/Resources/WindowResources.Designer.cs
+++ b/PixelMatcher/Resources/WindowResources.Designer.cs
@@ -68,6 +68,10 @@ namespace PixelMatcher.Resources {
         ///Press Page Up/Page Down to navigate through image history.
         ///Press Delete to remove current image.
         ///Press T to toggle window topmost mode.
+        ///Press M to minimize window.
+        ///Press F to maximize window.
+        ///Double-click window header to toggle Maximized mode.
+        ///Double-click Contrast slider to reset image contrast.
         ///Press Esc to close..
         /// </summary>
         public static string HelpText {

--- a/PixelMatcher/Resources/WindowResources.resx
+++ b/PixelMatcher/Resources/WindowResources.resx
@@ -125,6 +125,10 @@ Use arrow keys to move image by one pixel.
 Press Page Up/Page Down to navigate through image history.
 Press Delete to remove current image.
 Press T to toggle window topmost mode.
+Press M to minimize window.
+Press F to maximize window.
+Double-click window header to toggle Maximized mode.
+Double-click Contrast slider to reset image contrast.
 Press Esc to close.</value>
   </data>
 </root>

--- a/PixelMatcher/Views/MainWindow.xaml
+++ b/PixelMatcher/Views/MainWindow.xaml
@@ -42,6 +42,8 @@
     <Window.InputBindings>
         <KeyBinding Key="Esc" Command="{Binding ExitCommand}" CommandParameter="{Binding ElementName=MainWindow1}" />
         <KeyBinding Key="T" Command="{Binding ToggleTopmostCommand}" />
+        <KeyBinding Key="M" Command="{Binding MinimizeCommand}" CommandParameter="{Binding ElementName=MainWindow1}" />
+        <KeyBinding Key="F" Command="{Binding MaximizeCommand}" CommandParameter="{Binding ElementName=MainWindow1}" />
         <KeyBinding Key="F1" Command="{Binding HelpCommand}" CommandParameter="{Binding ElementName=MainWindow1}" />
         <KeyBinding Key="H" Command="{Binding HelpCommand}" CommandParameter="{Binding ElementName=MainWindow1}" />
         <KeyBinding Key="Delete" Command="{Binding DeleteCurrentImageCommand}" />
@@ -60,11 +62,26 @@
             <Canvas ClipToBounds="True">
                 <Image HorizontalAlignment="Center"
                        VerticalAlignment="Center"
+                       Focusable="True"
+                       RenderOptions.BitmapScalingMode="NearestNeighbor"
+                       RenderTransformOrigin="0,0"
+                       Source="{Binding BackgroundImageSource}"
+                       Stretch="None">
+                    <Image.RenderTransform>
+                        <TransformGroup>
+                            <ScaleTransform ScaleX="{Binding ZoomLevel}" ScaleY="{Binding ZoomLevel}" />
+                            <!--  Transforms order is important for correct Zoom&Pan functionality  -->
+                            <TranslateTransform X="{Binding BackgroundImagePositionX}" Y="{Binding BackgroundImagePositionY}" />
+                        </TransformGroup>
+                    </Image.RenderTransform>
+                </Image>
+                <Image HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       Focusable="True"
                        Opacity="{Binding ImageOpacity}"
                        RenderOptions.BitmapScalingMode="NearestNeighbor"
                        RenderTransformOrigin="0,0"
                        Source="{Binding ImageSource}"
-                       Focusable="True"
                        Stretch="None">
                     <Image.RenderTransform>
                         <TransformGroup>
@@ -99,12 +116,12 @@
                     <TextBlock Style="{StaticResource NoImagesText}">
                         <Run Text="Drop or paste image." />
                     </TextBlock>
-                    <TextBlock Width="70" Margin="10,0,5,0">
+                    <TextBlock Width="80" Margin="10,0,5,0">
                         <Run Text="Opacity: " />
                         <Run Text="{Binding ImageOpacity, StringFormat={}{0:0.##}}" />
                     </TextBlock>
                     <Slider Width="80"
-                            Margin="0,0,5,0"
+                            Margin="-10,0,5,0"
                             LargeChange="0.33"
                             Maximum="{x:Static viewModels:MainViewModel.MaximumOpacity}"
                             Minimum="{x:Static viewModels:MainViewModel.MinimumOpacity}"
@@ -115,7 +132,7 @@
                         <Run Text="{Binding ZoomLevel, StringFormat=x{0:0.0}}" />
                     </TextBlock>
                     <Slider Width="80"
-                            Margin="0,0,5,0"
+                            Margin="-20,0,5,0"
                             LargeChange="3"
                             Maximum="{x:Static viewModels:MainViewModel.MaximumZoomLevel}"
                             Minimum="{x:Static viewModels:MainViewModel.MinimumZoomLevel}"
@@ -126,22 +143,36 @@
                         <Run Text="{Binding ImageContrast}" />
                     </TextBlock>
                     <Slider Width="80"
-                            Margin="0,0,5,0"
+                            Margin="-5,0,5,0"
                             LargeChange="3"
                             Maximum="{x:Static viewModels:MainViewModel.MaximumContrast}"
                             Minimum="{x:Static viewModels:MainViewModel.MinimumContrast}"
                             SmallChange="1"
-                            Value="{Binding ImageContrast}" />
+                            Value="{Binding ImageContrast}">
+                        <i:Interaction.Triggers>
+                            <i:EventTrigger EventName="MouseDoubleClick">
+                                <i:InvokeCommandAction Command="{Binding ResetImageContrastCommand}" />
+                            </i:EventTrigger>
+                        </i:Interaction.Triggers>
+                    </Slider>
                 </StackPanel>
-                <Button HorizontalAlignment="Right"
+                <Button Width="24"
+                        HorizontalAlignment="Right"
                         Command="{Binding ExitCommand}"
                         CommandParameter="{Binding ElementName=MainWindow1}"
                         Content="✕"
                         DockPanel.Dock="Right" />
-                <Button HorizontalAlignment="Right"
+                <Button Width="24"
+                        HorizontalAlignment="Right"
+                        Command="{Binding MinimizeCommand}"
+                        CommandParameter="{Binding ElementName=MainWindow1}"
+                        Content="_"
+                        DockPanel.Dock="Right" />
+                <Button Width="24"
+                        HorizontalAlignment="Right"
                         Command="{Binding HelpCommand}"
                         CommandParameter="{Binding ElementName=MainWindow1}"
-                        Content="Help"
+                        Content="?"
                         DockPanel.Dock="Right" />
                 <StackPanel Margin="0,0,5,0"
                             HorizontalAlignment="Right"


### PR DESCRIPTION
On ZoomLevel change, make a screenshot of whole Desktop and set as main window background (simulate magnifier). Zoom x1 clears the background to see live desktop. Cltr+drag drags background image.

Small fixes:
 - added minimize hotkey (M);
 - added maximize hotkey (F);
 - added maximize on double-click;
 - added double-click on Contrast slider to reset contrast.